### PR TITLE
63 update user profile

### DIFF
--- a/frontend/src/user/profile/Profile.js
+++ b/frontend/src/user/profile/Profile.js
@@ -251,7 +251,7 @@ class Profile extends Component {
                                     <div className="row">
                                         <div className="col-md-4">••••••••••••••</div>
                                         <div className="col-md-4">
-                                            <MDBBtn color="danger" outline="true"  onClick={() => this.openPasswordModal()}> Update Password </MDBBtn>
+                                            <MDBBtn color="secondary" outline="true"  onClick={() => this.openPasswordModal()}> Update Password </MDBBtn>
                                         </div>
                                         <div className="col-md-4"></div>
                                         <Popup open={this.state.openPassword} modal>

--- a/frontend/src/user/profile/Profile.js
+++ b/frontend/src/user/profile/Profile.js
@@ -37,10 +37,19 @@ class Profile extends Component {
                 zipCode: localStorage.getItem("zipCode"),
                 telephone: localStorage.getItem("telephone")
             },
-            open: false
+            oldPassword: '',
+            newPassword: '',
+            confirmPassword: '',
+            open: false,
+            openPassword: false,
+            openPasswordSucceed: false
         };
-        this.openModal = this.openModal.bind(this)
-        this.closeModal = this.closeModal.bind(this)
+        this.openModal = this.openModal.bind(this);
+        this.closeModal = this.closeModal.bind(this);
+        this.openPasswordModal = this.openPasswordModal.bind(this);
+        this.closePasswordModal = this.closePasswordModal.bind(this);
+        this.openPasswordSucceedModal = this.openPasswordSucceedModal.bind(this);
+        this.closePasswordSucceedModal = this.closePasswordSucceedModal.bind(this)
     }
 
     openModal (){
@@ -51,8 +60,23 @@ class Profile extends Component {
         this.setState({ open: false })
     }
 
+    openPasswordModal (){
+        this.setState({ openPassword: true })
+    }
+
+    closePasswordModal () {
+        this.setState({ openPassword: false })
+    }
+
+    openPasswordSucceedModal (){
+        this.setState({ openPasswordSucceed: true })
+    }
+
+    closePasswordSucceedModal () {
+        this.setState({ openPasswordSucceed: false })
+    }
+
     componentDidMount() {
-        // this.loadUserFromServer()
         this.loadOrdersFromServer()
     }
 
@@ -63,9 +87,79 @@ class Profile extends Component {
     };
 
     changeHandler = event => {
+        this.setState({[event.target.name]: event.target.value});
+    };
+
+    changeUserHandler = event => {
         let updateUser = this.state.updateUser;
         updateUser[event.target.name]= event.target.value;
         this.setState({updateUser: updateUser})
+    };
+
+    updatePasswordHandler = () => {
+        const { oldPassword, newPassword, confirmPassword } = this.state;
+
+        if (oldPassword.length === 0) {
+            console.log(`Old password is empty.`);
+            alert("Old password is empty! Please, try again.")
+        } else if (newPassword.length === 0 || confirmPassword.length === 0) {
+            console.log(`New password is empty.`);
+            alert("New password is empty! Please, try again.")
+        } else {
+            var formData = new FormData();
+            formData.append("email", this.state.user.email);
+            formData.append("password", oldPassword);
+
+            const options = {
+                method: 'POST',
+                body: formData,
+                redirect: 'follow'
+            };
+            fetch('/user/login', options)
+                .then(response => {
+                        if (response.ok) {
+                            console.log(`Old password matches.`);
+                            if (newPassword !== confirmPassword) {
+                                console.log("Passwords do not match");
+                                alert("Passwords don't match");
+                            } else {
+                                console.log("Passwords match");
+
+                                const opt = {
+                                    headers: {
+                                        "Content-Type": "application/json",
+                                    },
+                                    method: 'PATCH',
+                                    body: JSON.stringify({"password": newPassword}),
+                                    redirect: 'follow'
+                                };
+
+                                fetch(`/user/update?id=${this.state.user.idUser}`, opt)
+                                    .then(response => {
+                                        if (response.ok) {
+                                            console.log('User password updated.');
+                                            this.closePasswordModal();
+                                            // window.location.reload();
+                                            this.openPasswordSucceedModal();
+                                        } else if (response.status === 403) {
+                                            console.log('Cannot update user password.');
+                                            alert("Cannot update password! Please, try again.")
+                                        }
+                                    })
+                            }
+                        } else if (response.status === 401) {
+                            console.log("Old password does not match.");
+                            alert("Old password is wrong! Please, try again.");
+                        }
+                    }
+                )
+        }
+    };
+
+    updatePasswordSucceedHandler = () => {
+        this.closePasswordSucceedModal();
+        localStorage.clear();
+        window.location.href=`/user/login`;
     };
 
     updateHandler = (event) => {
@@ -152,6 +246,142 @@ class Profile extends Component {
                             </div>
 
                             <div className="profile-info-row">
+                                <div className="profile-info-name"> Password</div>
+                                <div className="profile-info-value">
+                                    <div className="row">
+                                        <div className="col-md-4">••••••••••••••</div>
+                                        <div className="col-md-4">
+                                            <MDBBtn color="danger" outline="true"  onClick={() => this.openPasswordModal()}> Update Password </MDBBtn>
+                                        </div>
+                                        <div className="col-md-4"></div>
+                                        <Popup open={this.state.openPassword} modal>
+                                            <div className="container">
+                                                <MDBRow>
+                                                    <MDBCol md="6" className="mb-6">
+                                                        <h3><b>Change Password</b></h3>
+                                                    </MDBCol>
+                                                    <MDBCol md="5" className="mb-5"/>
+                                                    <MDBCol md="1" className="mb-1">
+                                                        <button onClick={() => this.closePasswordModal()}> &times; </button>
+                                                    </MDBCol>
+                                                </MDBRow>
+
+                                                <hr/>
+                                                <MDBRow>
+                                                    <MDBCol md="6" className="mb-6">
+                                                        <label
+                                                            htmlFor="defaultFormRegisterPasswordEx3"
+                                                            className="grey-text"
+                                                        >
+                                                            Old password
+                                                        </label>
+                                                        <input
+                                                            value={this.state.oldPassword}
+                                                            name="oldPassword"
+                                                            onChange={this.changeHandler}
+                                                            type="password"
+                                                            // id="defaultFormRegisterPasswordEx3"
+                                                            className="form-control"
+                                                            placeholder="Old password"
+                                                            required
+                                                        />
+                                                    </MDBCol>
+                                                </MDBRow>
+                                                <MDBRow>
+                                                    <MDBCol md="6" className="mb-6">
+                                                        <label
+                                                            htmlFor="defaultFormRegisterPasswordEx3"
+                                                            className="grey-text"
+                                                        >
+                                                            New password
+                                                        </label>
+                                                        <input
+                                                            value={this.state.newPassword}
+                                                            onChange={this.changeHandler}
+                                                            type="password"
+                                                            // id="defaultFormRegisterPasswordEx3"
+                                                            className="form-control"
+                                                            name="newPassword"
+                                                            placeholder="New password"
+                                                            required
+                                                        />
+                                                        <div className="invalid-feedback">
+                                                            Please provide a valid country.
+                                                        </div>
+                                                    </MDBCol>
+                                                </MDBRow>
+                                                <MDBRow>
+                                                    <MDBCol md="6" className="mb-6">
+                                                        <label
+                                                            htmlFor="defaultFormRegisterPasswordEx3"
+                                                            className="grey-text"
+                                                        >
+                                                            Confirm password
+                                                        </label>
+                                                        <input
+                                                            value={this.state.confirmPassword}
+                                                            onChange={this.changeHandler}
+                                                            type="password"
+                                                            // id="defaultFormRegisterPasswordEx3"
+                                                            className="form-control"
+                                                            name="confirmPassword"
+                                                            placeholder="New password"
+                                                            required
+                                                        />
+                                                        <div className="invalid-feedback">
+                                                            Please provide a valid street number.
+                                                        </div>
+                                                    </MDBCol>
+                                                </MDBRow>
+                                                <hr/>
+                                                <MDBRow>
+                                                    <MDBCol md="2" className="mb-2"/>
+                                                    <MDBCol md="2" className="mb-2"/>
+                                                    <MDBCol md="2" className="mb-2"/>
+                                                    <MDBCol md="2" className="mb-2"/>
+                                                    <MDBCol md="2" className="mb-2">
+                                                        <MDBBtn color="danger" onClick={this.closePasswordModal}> Cancel </MDBBtn>
+                                                    </MDBCol>
+                                                    <MDBCol md="2" className="mb-2">
+                                                        <MDBBtn color="success" onClick={this.updatePasswordHandler}> Update </MDBBtn>
+                                                    </MDBCol>
+                                                </MDBRow>
+
+                                            </div>
+                                        </Popup>
+                                        <Popup open={this.state.openPasswordSucceed} modal>
+                                            <div className="container">
+                                                <MDBRow>
+                                                    <MDBCol md="9" className="mb-9">
+                                                        <h3><b>Password changed successfully!</b></h3>
+                                                    </MDBCol>
+                                                </MDBRow>
+
+                                                <hr/>
+
+                                                <MDBRow>
+                                                    <MDBCol md="9" className="mb-9">
+                                                        <div><b>Your password has been reset successfully! To continue, press <i>OK</i> and log in with the new password.</b>
+                                                        </div>
+                                                    </MDBCol>
+                                                </MDBRow>
+                                                <hr/>
+                                                <MDBRow>
+                                                    <MDBCol md="4" className="mb-4"/>
+                                                    <MDBCol md="1" className="mb-1">
+                                                        <MDBBtn color="success" onClick={this.updatePasswordSucceedHandler}> OK </MDBBtn>
+                                                    </MDBCol>
+                                                    <MDBCol md="4" className="mb-4"/>
+
+                                                </MDBRow>
+
+                                            </div>
+                                        </Popup>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="profile-info-row">
                                 <div className="profile-info-name"> Location</div>
                                 <div className="profile-info-value">
                                     <span>{user.city}</span>
@@ -208,7 +438,7 @@ class Profile extends Component {
                                                     <input
                                                         value={this.state.updateUser.firstname}
                                                         name="firstname"
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="text"
                                                         id="defaultFormRegisterNameEx"
                                                         className="form-control"
@@ -225,7 +455,7 @@ class Profile extends Component {
                                                     <input
                                                         value={this.state.updateUser.lastname}
                                                         name="lastname"
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="text"
                                                         id="defaultFormRegisterSurnameEx2"
                                                         className="form-control"
@@ -243,7 +473,7 @@ class Profile extends Component {
                                                     </label>
                                                     <input
                                                         value={this.state.updateUser.city}
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="text"
                                                         id="defaultFormRegisterCountry7"
                                                         className="form-control"
@@ -263,7 +493,7 @@ class Profile extends Component {
                                                     </label>
                                                     <input
                                                         value={this.state.updateUser.streetName}
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="text"
                                                         id="defaultFormRegisterStNameEx5"
                                                         className="form-control"
@@ -285,7 +515,7 @@ class Profile extends Component {
                                                     </label>
                                                     <input
                                                         value={this.state.updateUser.streetNumber}
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="text"
                                                         id="defaultFormRegisterStNumEx6"
                                                         className="form-control"
@@ -305,7 +535,7 @@ class Profile extends Component {
                                                     </label>
                                                     <input
                                                         value={this.state.updateUser.zipCode}
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="text"
                                                         id="defaultFormRegisterZip8"
                                                         className="form-control"
@@ -327,7 +557,7 @@ class Profile extends Component {
                                                     </label>
                                                     <input
                                                         value={this.state.updateUser.country}
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="text"
                                                         id="defaultFormRegisterCountry7"
                                                         className="form-control"
@@ -348,7 +578,7 @@ class Profile extends Component {
                                                     </label>
                                                     <input
                                                         value={this.state.updateUser.telephone}
-                                                        onChange={this.changeHandler}
+                                                        onChange={this.changeUserHandler}
                                                         type="tel"
                                                         id="defaultFormRegisterTel9"
                                                         className="form-control"
@@ -378,6 +608,9 @@ class Profile extends Component {
 
                                         </div>
                                     </Popup>
+                                </div>
+                                <div className="profile-info-name">
+
                                 </div>
                             </div>
                         </div>

--- a/src/main/java/se/uu/elephas/controllers/UserController.java
+++ b/src/main/java/se/uu/elephas/controllers/UserController.java
@@ -30,12 +30,6 @@ public class UserController {
     @Autowired
     private OrderServiceImpl orderService;
 
-    @RequestMapping("/")
-    public String home() {
-        return "Hello Elephas!";
-    }
-
-
     @RequestMapping(value = "/create", method = {RequestMethod.POST})
     public ResponseEntity<String> create(
             @RequestBody User user)
@@ -89,12 +83,14 @@ public class UserController {
     public ResponseEntity<String> update(
             @RequestParam("id") @Valid Long id,
             @RequestBody User user)
-            throws JsonProcessingException {
+            throws NoSuchAlgorithmException, JsonProcessingException {
+
+        MessageDigest md = MessageDigest.getInstance("MD5");
 
         Object updatedUser;
 
         try {
-            updatedUser = userService.update(user, id);
+            updatedUser = userService.update(user, id, md);
         } catch (ConstraintViolationException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("User with id " + id + "cannot be updated.");
         }

--- a/src/main/java/se/uu/elephas/services/UserService.java
+++ b/src/main/java/se/uu/elephas/services/UserService.java
@@ -13,7 +13,7 @@ public interface UserService {
 
     void delete(Long id);
 
-    Object update(User user, Long id);
+    Object update(User user, Long id, MessageDigest md);
 
     Iterable<User> getAll();
 

--- a/src/main/java/se/uu/elephas/services/UserServiceImpl.java
+++ b/src/main/java/se/uu/elephas/services/UserServiceImpl.java
@@ -55,7 +55,7 @@ public class UserServiceImpl implements UserService {
 
     // TODO: try-catch or if-else in case that user does not exist
     // TODO: create token from new password
-    public Object update(User newUser, Long id) {
+    public Object update(User newUser, Long id, MessageDigest md) {
         newUser.setIdUser(id);
         Optional<User> optUser = userRepository.findById(id);
 
@@ -66,6 +66,19 @@ public class UserServiceImpl implements UserService {
 
             if (newUser.getPassword() == null)
                 newUser.setPassword(user.getPassword());
+            else {
+                md.update(newUser.getPassword().getBytes());
+                byte[] digest = md.digest();
+                String hashed = DatatypeConverter.printHexBinary(digest);
+
+                newUser.setPassword(hashed);
+
+                SecureRandom random = new SecureRandom();
+                byte bytes[] = new byte[20];
+                random.nextBytes(bytes);
+                String token = bytes.toString();
+                newUser.setToken(token);
+            }
 
             if (newUser.getFirstname() == null)
                 newUser.setFirstname(user.getFirstname());


### PR DESCRIPTION
* Added field with password in user's profile (dots instead of password)
* Added button for update password, where user is asked to put their current password and the new twice.
  * Alert windows in case of error (empty passwords, confirm password is not the same with the new password, old password is not the right one)
  * Handled all the possible errors from backend
  * Fixed bug in the backend - in case of password update save the hash and not the password (we were saving the password)
* Added button for Edit Profile, where a popup opens with all the fields that the user can update (all except for email and password). In the boxes the current values are shown. The user does not need to update all the fields.
* After successful password update, a new popup is shown where the user must press ok to go to the login page and log in with the new password - the localStorage is cleaned so the session of the user is deleted and the user must log in again